### PR TITLE
Use style and weight from primary font

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,11 +45,13 @@ module.exports = function(fonts, size, lineHeight) {
       var maybeWeight = parts[parts.length - 1].toLowerCase();
       if (maybeWeight == 'normal' || maybeWeight == 'italic' || maybeWeight == 'oblique') {
         style = haveStyle ? style : maybeWeight;
+        haveStyle = true;
         parts.pop();
         maybeWeight = parts[parts.length - 1].toLowerCase();
       } else if (italicRE.test(maybeWeight)) {
         maybeWeight = maybeWeight.replace(italicRE, '');
         style = haveStyle ? style : parts[parts.length - 1].replace(maybeWeight, '');
+        haveStyle = true;
       }
       for (var w in fontWeights) {
         var previousPart = parts.length > 1 ? parts[parts.length - 2].toLowerCase() : '';
@@ -64,6 +66,7 @@ module.exports = function(fonts, size, lineHeight) {
       }
       if (!haveWeight && typeof maybeWeight == 'number') {
         weight = maybeWeight;
+        haveWeight = true;
       }
       var fontFamily = parts.join(sp)
         .replace('Klokantech Noto Sans', 'Noto Sans');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -17,6 +17,10 @@ describe('mapbox-to-css-font', function() {
       should(parseFont('monospace', 16, 3.5)).eql('normal 400 16px/3.5 monospace');
       should(parseFont('monospace', 16, '3em')).eql('normal 400 16px/3em monospace');
     });
+
+    it('use style and weight from primary font', function() {
+      should(parseFont(['monospace medium Italic', 'sans-serif Normal'], 16)).eql('italic 500 16px monospace,sans-serif');
+    });
   });
 
 });


### PR DESCRIPTION
This pull request fixes the behavior when an array of font families is passed. Previously, the style from the last font was used, now the one from the primary font is used, as advertised.